### PR TITLE
Correctly parse repeated header entries

### DIFF
--- a/lib/src/impl/util_read.dart
+++ b/lib/src/impl/util_read.dart
@@ -133,9 +133,17 @@ class FrameParser {
         final int k = line.indexOf(':');
         final String name = k >= 0 ? line.substring(0, k): line,
           value = k >= 0 ? line.substring(k + 1): "";
-        if (_frame.headers == null)
-          _frame.headers = new LinkedHashMap();
-        _frame.headers[_unescape(name)] = _unescape(value);
+        
+        final String unescapedName = _unescape(name);        
+        if (!_frame.headers.containsKey(unescapedName)) {
+          // There can be repeated entries in headers.
+          // Using first one according to spec.
+          // See "Repeated Header Entries".
+          if (_frame.headers == null)
+            _frame.headers = new LinkedHashMap();
+          
+          _frame.headers[unescapedName] = _unescape(value);
+        }
       }
 
       i = string.indexOf('\n', pre);


### PR DESCRIPTION
Message headers like this are not correctly parsed:

```
MESSAGE
subscription:id
ack:3
message-id:apollo-default-d41
reply-to:/queue/temp.default.apollo-default-d4.local
reply-to:/temp-queue/local
destination:/queue/manager
content-length:333
```

According to http://stomp.github.io/stomp-specification-1.2.html#Repeated_Header_Entries the first 'reply-to' has to be used as header value.
