### PR TITLE
Correctly parse repeated header entries

### DIFF
--- a/lib/src/impl/util_read.dart
+++ b/lib/src/impl/util_read.dart
@@ -133,7 +133,6 @@ class FrameParser {
         final int k = line.indexOf(':');
         final String name = k >= 0 ? line.substring(0, k): line,
           value = k >= 0 ? line.substring(k + 1): "";
-
         if (_frame.headers == null)
           _frame.headers = new LinkedHashMap();
           


### PR DESCRIPTION
Repeated headers are not parsed correctly when repeated entries occour. In this case just the last entry is used. According to the spec at http://stomp.github.io/stomp-specification-1.2.html#Repeated_Header_Entries the first entry has to be used as value.
