### PR TITLE
Allow Glob matches in destinations.

### DIFF
--- a/lib/src/stomp_util.dart
+++ b/lib/src/stomp_util.dart
@@ -9,23 +9,26 @@ const int _SUB_BYTES = 0, _SUB_STRING = 1, _SUB_JSON = 2, _SUB_BLOB = 3;
 class _Subscriber {
   final String id;
   final String destination;
+  final DestinationType destinationType;
   final int type;
   final Function onMessage;
   final Ack ack;
 
   _Subscriber.bytes(this.id, this.destination,
       void onMessage(Map<String, String> headers, List<int> message),
-      this.ack): type = _SUB_BYTES, this.onMessage = onMessage;
+      this.ack, this.destinationType): type = _SUB_BYTES, this.onMessage = onMessage;
   _Subscriber.string(this.id, this.destination,
       void onMessage(Map<String, String> headers, String message),
-      this.ack): type = _SUB_STRING, this.onMessage = onMessage;
+      this.ack, this.destinationType): type = _SUB_STRING, this.onMessage = onMessage;
   _Subscriber.json(this.id, this.destination,
       void onMessage(Map<String, String> headers, message),
-      this.ack): type = _SUB_JSON, this.onMessage = onMessage;
+      this.ack, this.destinationType): type = _SUB_JSON, this.onMessage = onMessage;
   _Subscriber.blob(this.id, this.destination,
       void onMessage(Map<String, String> headers, Stream<List<int>> message),
-      this.ack): type = _SUB_BLOB, this.onMessage = onMessage;
+      this.ack, this.destinationType): type = _SUB_BLOB, this.onMessage = onMessage;
 
+  bool destinationMatches(String destination) => destinationType.matches(this.destination, destination);
+  
   Future onFrame(Frame frame)
   => new Future(() { //to avoid the callback might cause some effect
       switch (type) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,11 @@
 name: stomp
-version: 0.5.5
 author: Tom Yeh <tomyeh@rikulo.org>
-description: Dart STOMP client for easy messaging interoperability.
+version: 0.5.5
 homepage: https://github.com/rikulo/stomp
+description: Dart STOMP client for easy messaging interoperability.
 documentation: http://api.rikulo.org/stomp/latest
-dependencies:
-  unittest: any
 environment:
-  sdk: ">=0.8.7"
+  sdk: '>=0.8.7'
+dependencies:
+  quiver: any
+  unittest: any


### PR DESCRIPTION
This will allow subscribing to topics using Glob pattern matching.  For example, subscribing to `"/app/stock.*"` will let you receive messages sent to `"/app/stock.GOOG"` and `"/app/stock.AAPL"`.
