### PR TITLE
2 sets of fixes. Connection error handling and first frame accessibility

### DIFF
--- a/lib/impl/util.dart
+++ b/lib/impl/util.dart
@@ -8,7 +8,7 @@ import "dart:convert" show UTF8;
 import "dart:collection" show LinkedHashMap;
 import "plugin.dart" show StompConnector;
 
-import "../stomp.dart" show CONTENT_LENGTH, CONTENT_TYPE;
+import "../stomp.dart" show CONTENT_LENGTH, CONTENT_TYPE, Frame;
 
 part "../src/impl/util_read.dart";
 part "../src/impl/util_write.dart";

--- a/lib/src/impl/util_read.dart
+++ b/lib/src/impl/util_read.dart
@@ -1,4 +1,5 @@
 //Copyright (C) 2013 Potix Corporation. All Rights Reserved.
+//Copyright (C) 2013 Potix Corporation. All Rights Reserved.
 //History: Sat, Aug 10, 2013 12:02:54 AM
 // Author: tomyeh
 part of stomp_impl_util;
@@ -8,23 +9,23 @@ part of stomp_impl_util;
  * Depending on [STOMPConnector], one of [bytes] and [string] might be
  * not null.
  */
-class Frame {
-  String command;
-  Map<String, String> headers;
-  String string;
-  List<int> bytes;
-
-  ///Returns the String-typed message of this frame (never null).
+class StompFrame extends Frame {
+  
+  ///Returns the String-typed message of this StompFrame (never null).
   ///It will detect if string or bytes is not null and pick up the right one.
+  @override
   String get message =>
     string != null ? string: bytes != null ? UTF8.decode(bytes): "";
-  ///Returns the byte-array message of this frame (never null).
+  
+  ///Returns the byte-array message of this StompFrame (never null).
   ///It will detect if string or bytes is not null and pick up the right one.
+  @override
   List<int> get messageBytes =>
      bytes != null ? bytes: string != null ? UTF8.encode(string): [];
 
   ///Retrieve the content length from the header; null means not available
-  int get _contentLength {
+  @override
+  int get contentLength {
     if (headers != null) {
       final String val = headers[CONTENT_LENGTH];
       if (val != null)
@@ -64,7 +65,7 @@ class FrameParser {
   final _OnError _onError;
 
   ///The current frame
-  Frame _frame = new Frame();
+  Frame _frame = new StompFrame();
   ///The body length of the current frame if content-length is received
   int _bodylen;
   ///The state
@@ -125,7 +126,7 @@ class FrameParser {
         }
       } else if (line.isEmpty) {
         _state = _BODY;
-        _bodylen = _frame._contentLength;
+        _bodylen = _frame.contentLength;
         if (i < string.length)
           _addBodyFrag(string.substring(i));
         return;
@@ -218,7 +219,7 @@ class FrameParser {
   }
   void _frameFound() {
     final Frame frame = _frame;
-    _frame = new Frame();
+    _frame = new StompFrame();
     _bodylen = null;
     _state = _COMMAND;
     _onFrame(frame);
@@ -238,7 +239,7 @@ class FrameParser {
     _strbuf.clear();
     if (!_bytebuf.isEmpty)
       _bytebuf = [];
-    _frame = new Frame();
+    _frame = new StompFrame();
     _bodylen = null;
 
     if (_onError != null)

--- a/lib/src/stomp_impl.dart
+++ b/lib/src/stomp_impl.dart
@@ -175,7 +175,7 @@ class _StompClient implements StompClient {
     _checkSend();
     writeDataFrame(_connector, SEND,
       _headerOfSend(headers, destination, "application/json"),
-      JSON.encode(message));
+      JSON.encoder.convert(message));
   }
 
   @override
@@ -336,7 +336,7 @@ class _StompClient implements StompClient {
     if (connecting != null) {
       //FUTURE: check version
       _connecting = null;
-      connecting.complete(this);
+      connecting.complete({ "stompClient": this, "frame": frame });
     }
   }
   void _error(Frame frame) {

--- a/lib/stomp.dart
+++ b/lib/stomp.dart
@@ -41,6 +41,27 @@ const Matcher GLOB = const _GlobMatcher();
 const Matcher REG_EXP = const _RegExpMatcher();
 
 /**
+ * A STOMP Frame encapsulating the details of a stomp communication
+ */
+abstract class Frame {
+  String command;
+  Map<String, String> headers;
+  String string;
+  List<int> bytes;
+  
+  ///Returns the String-typed message of this StompFrame (never null).
+  ///It will detect if string or bytes is not null and pick up the right one.
+  String get message;
+  
+  ///Returns the byte-array message of this StompFrame (never null).
+  ///It will detect if string or bytes is not null and pick up the right one.
+  List<int> messageBytes;
+ 
+  ///Retrieve the content length from the header; null means not available
+  int get contentLength;
+}
+
+/**
  * A STOMP client.
  */
 abstract class StompClient {

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -4,6 +4,7 @@
 library parser_test;
 
 import "dart:convert" show UTF8;
+import "package:stomp/stomp.dart" show Frame;
 import 'package:unittest/unittest.dart';
 import 'package:stomp/impl/util.dart';
 


### PR DESCRIPTION
Hi Tom.  Some important details on this request:

```
* Fixes issue where connection failures due to 302 and other http (upgrade request) failures cause the client to NPE by allowing to define a connectionError function to pass in and handle.  Bug was system was trying to invoke a null onClose handler because websocket was not yet established.  This was uncovered in working with Spring4 websocket support with security in place.

* Fixes the need (and lack of ability) to get information about the connection frames.  Use case here was Spring STOMP/Websocket implementation passes custom header user-name on CONNECT and there was no way to get ahold of it.
```

Probably you won't want to adopt this pull request in whole.  Unfortunately I ended up changing the basic interface - the Future from connect() now returns a Map instead of a StompClient.

connecting.complete({ "stompClient": this, "frame": frame });

There may be a better way to do this like "'stompClient.getFirstFrame()" or something.  I can make appropriate changes if you want to make a suggestion, and offer another pull request.  Or if you make the changes please let me know.

Another thing that might be nice is to be able to get knowledge of the status code from the connection attempt.  Right now I just have to guess that if it didn't work, it was due to 302.  It wasn't immediately obvious how to fix that in the websocket stuff.
