### PR TITLE
Use only subscriptionId for subscription matching

### DIFF
--- a/lib/src/stomp_impl.dart
+++ b/lib/src/stomp_impl.dart
@@ -371,7 +371,7 @@ class _StompClient implements StompClient {
       final String id = headers["subscription"];
       if (id != null) {
         final _Subscriber sub = _subscribers[id];
-        if (sub != null && sub.matches(headers)) {
+        if (sub != null) {
           sub.onFrame(frame)
             .catchError((error, stackTrace) {
               _handleFault(error, stackTrace);

--- a/lib/src/stomp_util.dart
+++ b/lib/src/stomp_util.dart
@@ -26,9 +26,6 @@ class _Subscriber {
   _Subscriber.blob(this.id, this.destination,
       void onMessage(Map<String, String> headers, Stream<List<int>> message),
       this.ack, this.matcher): type = _SUB_BLOB, this.onMessage = onMessage;
-
-  bool matches(Map<String, String> headers)
-  => matcher.matches(this.destination, headers["destination"]);
   
   Future onFrame(Frame frame)
   => new Future(() { //to avoid the callback might cause some effect

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stomp
 author: Tom Yeh <tomyeh@rikulo.org>
-version: 0.7.1
+version: 0.7.2
 homepage: https://github.com/rikulo/stomp
 description: Dart STOMP client for easy messaging interoperability.
 documentation: http://api.rikulo.org/stomp/latest


### PR DESCRIPTION
Based on [STOMP 1.2 spec](http://stomp.github.io/stomp-specification-1.2.html#MESSAGE), subscription matching should rely only on subscriptionId, not on subscriptionId + destination.

I hit this bug when using STOMP Dart client with a Spring 4.0.3 server with [@SubscribeMapping annotation](http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#websocket-stomp-handle-annotations). In the case the SUBSCRIBE destination is /app/aaaaaa and the MESSAGE destination received is /aaaaaa with matching subscriptionId. Based on STOMP 1.2 spec, I think Spring implementation is correct.

If you agree with this fix, could you release Stomp client 0.7.2 since I need this in my [OpenSnap](https://github.com/sdeleuze/opensnap) Spring + Dart SnapChat clone ?
