### PR TITLE
Removing ByteBuffer Declaration

### DIFF
--- a/lib/websocket.dart
+++ b/lib/websocket.dart
@@ -4,7 +4,7 @@
 library stomp_websocket;
 
 import "dart:async";
-import "dart:html" show WebSocket, MessageEvent, ByteBuffer;
+import "dart:html" show WebSocket, MessageEvent;
 
 import "stomp.dart" show StompClient;
 import "impl/plugin.dart" show StringStompConnector;


### PR DESCRIPTION
Warning from Dart2JS: Library 'dart:html' doesn't export a 'ByteBuffer' declaration.

ByteBuffer is in the dart-typed_data package (not neccesary here)